### PR TITLE
Incorrectly formatted JSON in challenge response

### DIFF
--- a/slackeventsapi/server.py
+++ b/slackeventsapi/server.py
@@ -108,7 +108,7 @@ class SlackServer(Flask):
             # Echo the URL verification challenge code back to Slack
             if "challenge" in event_data:
                 return make_response(
-                    {"challenge": event_data.get("challenge")}, 200, 
+                    {"challenge": event_data.get("challenge")}, 200,
                     {"content_type": "application/json"}
                 )
 

--- a/slackeventsapi/server.py
+++ b/slackeventsapi/server.py
@@ -108,7 +108,8 @@ class SlackServer(Flask):
             # Echo the URL verification challenge code back to Slack
             if "challenge" in event_data:
                 return make_response(
-                    event_data.get("challenge"), 200, {"content_type": "application/json"}
+                    {"challenge": event_data.get("challenge")}, 200, 
+                    {"content_type": "application/json"}
                 )
 
             # Parse the Event payload and emit the event to the event listener


### PR DESCRIPTION
###  Summary

This issue was discovered running Slack in a UAT environment - probably a more recent version of Slack than prod, but I don't know what version. It looks like this is not a regression in the code, but a change on the Slack side to be more picky about the response. The code is wrong, but it has worked.

See: https://api.slack.com/events/url_verification

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/python-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
